### PR TITLE
v0.9.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,22 @@
 - refactor: merge alias.ts into resolve.ts
 - refactor: use resolve only
 - refactor: migration alias to resolve
+
+## [2022-06-09] v0.9.7-beta2
+
+- 8c7a026 backup(v0.9.7): remove files
+- 9d61af8 test(v0.9.7-beta2): UPD main-output.js
+- d070477 backup(v0.9.7): rename files
+- d0c6147 refactor(v0.9.7-beta2): better logic
+- ca85c88 feat: `tryFixGlobSlash()`, `toDepthGlob()`, `mappingPath()`
+- 1e9b102 chore: optimize code
+- 6748dab feat: dynamic-import-to-glob.ts
+- 065d945 chore: test based on vite.config.ts
+- bd6a933 chore: optimize code
+
+## [2022-06-09] v0.9.8
+
+- 5807515 feat: `resolve.parseImportee()`
+- 0054f4a chore: remove `extractImporteeRE`, `isRaw()`, `parseImportee()`
+- cb39a4a fix: use `String.slice()` instead of `parseImportee()`
+- 603a256 fix: use `String.slice()` instead of `RegExp`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-dynamic-import",
-  "version": "0.9.7",
+  "version": "0.9.8",
   "description": "Enhance Vite builtin dynamic import",
   "main": "dist/index.js",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,6 @@ import {
   KNOWN_SFC_EXTENSIONS,
   MagicString,
   cleanUrl,
-  extractImporteeRE,
   hasDynamicImport,
   normallyImporteeRE,
   simpleWalk,
@@ -86,7 +85,7 @@ export default function dynamicImport(options: Options = {}): Plugin {
           }
 
           if (node.source.type === 'Literal') {
-            const [, , importee] = importeeRaw.match(extractImporteeRE)
+            const importee = importeeRaw.slice(1, -1)
             // empty value
             if (!importee) return
             // normally importee

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -65,7 +65,7 @@ export class Resolve {
   private tryResolveBare(importee: string, importer: string): Resolved {
     const { importee: ipte, importeeRaw = ipte } = this.parseImportee(importee)
 
-    // It's relative or absolute path
+    // it's relative or absolute path
     if (/^[\.\/]/.test(ipte)) {
       return
     }
@@ -112,13 +112,14 @@ export class Resolve {
     } = this.parseImportee(importee)
 
     if (replacement.startsWith('.')) {
-      // Relative path
+      // relative path
       ipte = ipte.replace(find, replacement)
     } else {
+      // to calculate the relative path
       const normalId = normalizePath(importer)
       const normalReplacement = normalizePath(replacement)
 
-      // Compatible with vite restrictions
+      // compatible with vite restrictions
       // https://github.com/vitejs/vite/blob/1e9615d8614458947a81e0d4753fe61f3a277cb3/packages/vite/src/node/plugins/importAnalysis.ts#L672
       let relativePath = path.relative(
         // Usually, the `replacement` we use is the directory path
@@ -131,7 +132,7 @@ export class Resolve {
       }
       const relativeImportee = relativePath + '/' + ipte
         .replace(find, '')
-        // Remove the beginning /
+        // remove the beginning /
         .replace(/^\//, '')
       ipte = relativeImportee
     }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,8 +7,6 @@ import type { Resolved } from './resolve'
 export const dynamicImportRE = /\bimport[\s\r\n]*?\(/
 // this is probably less accurate
 export const normallyImporteeRE = /^\.{1,2}\/[.-/\w]+(\.\w+)$/
-// [, startQuotation, importee, endQuotation]
-export const extractImporteeRE = /^([`'"]{1})(.*)([`'"]{1})$/
 export const viteIgnoreRE = /\/\*\s*@vite-ignore\s*\*\//
 export const multilineCommentsRE = /\/\*(.|[\r\n])*?\*\//g
 export const singlelineCommentsRE = /\/\/.*/g
@@ -106,20 +104,6 @@ export class MagicString {
     }
     return this.starts + str + this.ends
   }
-}
-
-
-export function isRaw(importee: string) {
-  return /^[`'"]/.test(importee)
-}
-
-export function parseImportee(importee: string) {
-  let [startQuotation, imptee] = ['', importee, '']
-  const matched = importee.match(extractImporteeRE)
-  if (matched) {
-    [, startQuotation, imptee] = matched
-  }
-  return [startQuotation, imptee]
 }
 
 // In some cases, glob may not be available

--- a/test/src/main-output.js
+++ b/test/src/main-output.js
@@ -20,7 +20,7 @@
     document.querySelector(".view").innerHTML = msg;
   }
   async function setView6() {
-    const { msg } = await import('./views/foo.js');
+    const { msg } = await import("./views/foo.js");
     document.querySelector(".view").innerHTML = msg;
   }
   async function setView7(id) {
@@ -167,9 +167,6 @@ function __variableDynamicImportRuntime4__(path) {
 }
 function __variableDynamicImportRuntime5__(path) {
   switch (path) {
-    case '@/main-output':
-    case '@/main-output.js':
-      return import('./main-output.js');
     case '@/main':
     case '@/main.ts':
       return import('./main.ts');


### PR DESCRIPTION
[fix: use String.slice() instead of RegExp](https://github.com/vite-plugin/vite-plugin-dynamic-import/commit/9bb19cc7fb40e40a0f1dcbc8171cb8733b304ae0)
[fix: use String.slice() instead of parseImportee](https://github.com/vite-plugin/vite-plugin-dynamic-import/commit/380b1300df35a10180447ed5eab37ec922861de0)
[chore: remove extractImporteeRE, isRaw(), parseImportee()](https://github.com/vite-plugin/vite-plugin-dynamic-import/commit/36edc77a2f4a06e55024c13ba8a22e5edf43088d)
[feat: resolve.parseImportee()](https://github.com/vite-plugin/vite-plugin-dynamic-import/commit/a52709322b00f524b98979e9cb4de34af1b3fb08)