### PR TITLE
v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,18 @@
 
 ## [2022-06-13] v0.9.9
 
-84eda9b test: v0.9.9
-c7f0799 docs: v0.9.9
-e9f65e9 fix(🐞): skip itself from glob
-2b38f0f test: optimize code
-809d818 docs: update
-ec9036d remove types.ts
-23af7ee chore: AcornNode
-8adc6fe Merge pull request #9 from vite-plugin/dev
-bd74200 chore: comments
+- 84eda9b test: v0.9.9
+- c7f0799 docs: v0.9.9
+- e9f65e9 fix(🐞): skip itself from glob
+- 2b38f0f test: optimize code
+- 809d818 docs: update
+- ec9036d remove types.ts
+- 23af7ee chore: AcornNode
+- 8adc6fe Merge pull request #9 from vite-plugin/dev
+- bd74200 chore: comments
+
+## [2022-06-13] v0.9.9
+
+- 71af433 docs: v1.0.0
+- 45eace4 chore:more exact match `.vite/`
+- ebd993c 🚨:use `options.loose` instead of `options.depth`

--- a/README.md
+++ b/README.md
@@ -40,10 +40,11 @@ dynamicImport([options])
 export interface Options {
   filter?: (id: string) => false | void
   /**
-   * This option will change `./*` to `./** /*`
+   * 1. `true` - Match all possibilities as much as possible, more like `webpack`
+   * 2. `false` - It behaves more like `@rollup/plugin-dynamic-import-vars`
    * @default true
    */
-  depth?: boolean
+  loose?: boolean
   /**
    * If you want to exclude some files  
    * e.g `type.d.ts`, `interface.ts`

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -41,10 +41,11 @@ dynamicImport([options])
 export interface Options {
   filter?: (id: string) => false | void
   /**
-   * 这个选项将会把 `./*` 变成 `./** /*`
+   * 1. `true` - 尽量匹配所有可能场景, 功能更像 `webpack`
+   * 2. `false` - 功能更像rollup的 `@rollup/plugin-dynamic-import-vars`插件
    * @default true
    */
-  depth?: boolean
+  loose?: boolean
   /**
    * 如果你想排除一些文件  
    * 举俩🌰 `type.d.ts`, `interface.ts`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-dynamic-import",
-  "version": "0.9.9",
+  "version": "1.0.0",
   "description": "Enhance Vite builtin dynamic import",
   "main": "dist/index.js",
   "repository": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,7 +62,7 @@ export default function dynamicImport(options: Options = {}): Plugin {
     async transform(code, id) {
       const pureId = cleanUrl(id)
 
-      if (/node_modules\/(?!\.vite)/.test(pureId)) return
+      if (/node_modules\/(?!\.vite\/)/.test(pureId)) return
       if (!extensions.includes(path.extname(pureId))) return
       if (!hasDynamicImport(code)) return
       if (options.filter?.(pureId) === false) return

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,10 +27,11 @@ export * as utils from './utils'
 export interface Options {
   filter?: (id: string) => false | void
   /**
-   * This option will change `./*` to `./** /*`
+   * 1. `true` - Match all possibilities as much as possible, more like `webpack`
+   * 2. `false` - It behaves more like `@rollup/plugin-dynamic-import-vars`
    * @default true
    */
-  depth?: boolean
+  loose?: boolean
   /**
    * If you want to exclude some files  
    * e.g `type.d.ts`, `interface.ts`
@@ -106,7 +107,7 @@ export default function dynamicImport(options: Options = {}): Plugin {
             id,
             resolve,
             globExtensions,
-            options.depth === false ? false : true,
+            options.loose === false ? false : true,
           )
           if (!globResult) return
 


### PR DESCRIPTION
- 71af433 docs: v1.0.0
- 45eace4 chore:more exact match `.vite/`
- ebd993c 🚨:use `options.loose` instead of `options.depth`