### PR TITLE
V1.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 
+## [2022-09-08] v1.2.2
+
+- dab79aa refactor: build cjs with Vite 🌱
+- c319816 bump vite, typescript
+- 238473b move fast-glob, vite-plugin-utils to devDependencies
+
 ## [2022-09-03] v1.2.1
 
 - 5940444 feat(🌱): support "type": "module" #29

--- a/package.json
+++ b/package.json
@@ -30,8 +30,8 @@
   "devDependencies": {
     "@types/node": "^17.0.33",
     "fast-glob": "^3.2.11",
-    "typescript": "^4.6.4",
-    "vite": "^2.9.9",
+    "typescript": "^4.7.4",
+    "vite": "^3.0.9",
     "vite-plugin-utils": "^0.3.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "vite-plugin-dynamic-import",
   "version": "1.2.1",
   "description": "Enhance Vite builtin dynamic import",
-  "main": "./dist/index.js",
+  "main": "./dist/index.mjs",
   "types": "src",
   "exports": {
     ".": {
@@ -17,12 +17,8 @@
   "author": "草鞋没号 <308487730@qq.com>",
   "license": "MIT",
   "scripts": {
-    "dev": "node build.js --watch",
-    "dev:es": "vite build --watch",
-    "dev:cjs": "tsc --watch",
-    "build": "node build.js",
-    "build:es": "vite build",
-    "build:cjs": "tsc",
+    "dev": "vite build --watch",
+    "build": "vite build",
     "test": "vite -c test/vite.config.ts",
     "prepublishOnly": "rm -rf dist && npm run build"
   },

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.1",
   "description": "Enhance Vite builtin dynamic import",
   "main": "./dist/index.js",
+  "types": "src",
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
@@ -25,14 +26,13 @@
     "test": "vite -c test/vite.config.ts",
     "prepublishOnly": "rm -rf dist && npm run build"
   },
-  "dependencies": {
-    "fast-glob": "~3.2.11",
-    "vite-plugin-utils": "~0.3.0"
-  },
+  "dependencies": {},
   "devDependencies": {
     "@types/node": "^17.0.33",
+    "fast-glob": "^3.2.11",
     "typescript": "^4.6.4",
-    "vite": "^2.9.9"
+    "vite": "^2.9.9",
+    "vite-plugin-utils": "^0.3.0"
   },
   "keywords": [
     "vite",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-dynamic-import",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Enhance Vite builtin dynamic import",
   "main": "./dist/index.mjs",
   "types": "src",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -9,8 +9,8 @@ export default defineConfig({
     emptyOutDir: false,
     lib: {
       entry: path.join(__dirname, 'src/index.ts'),
-      formats: ['es'],
-      fileName: () => '[name].mjs',
+      formats: ['es', 'cjs'],
+      fileName: format => format === 'es' ? '[name].mjs' : '[name].js',
     },
     rollupOptions: {
       external: [


### PR DESCRIPTION
## [2022-09-08] v1.2.2

- dab79aa refactor: build cjs with Vite 🌱
- c319816 bump vite, typescript
- 238473b move fast-glob, vite-plugin-utils to devDependencies