### PR TITLE
V1.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,5 +110,3 @@ pnpm-lock.yaml
 yarn.lock
 
 /types
-/index.cjs
-/index.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [2023-04-27] v1.3.0
+
+- 8972bb4 v1.3.0
+- f7a3ab8 doc: v1.3.0
+- b34ada6 test: v1.3.0
+- 2a4f240 chore: comments
+- 17b1eb0 refactor: performance, support node_modules, custom resolve importee
+- 8dd5cac feat: integrate vitest 🌱
+- 2ea165f chore: cleanup
+
 ## [2023-01-20] v1.2.7
 
 - 53ecc11 feat: generate types #44

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
-## [2023-04-27] v1.3.0
+## [2023-04-28] v1.3.0
 
+**Main changes**
+
+- support Vite's [Pre-Bundling](https://vitejs.dev/guide/dep-pre-bundling.html#dependency-pre-bundling) for [vite-plugin-dynamic-import/issues/48](https://github.com/vite-plugin/vite-plugin-dynamic-import/issues/48)
+- use the `es-module-lexer` improve performance
+- integrate `vitest` 🌱
+
+**Full commits**
+
+- babb391 docs: v1.3.0
+- 0949d3f feat: better build
+- c4ef2f6 feat: support Pre-Bundling
+- 966eca5 chore: types
+- 2d090cb chore: cleanup
+- b1a5bab fix: filter `node_modules`, `import.meta`
+- e75e3bc log: v1.3.0
 - 8972bb4 v1.3.0
 - f7a3ab8 doc: v1.3.0
 - b34ada6 test: v1.3.0

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cases 👉 [vite-plugin-dynamic-import/test](https://github.com/vite-plugin/vite
 dynamicImport({
   filter(id) {
     // `node_modules` is exclude by default, so we need to include it explicitly
-    // https://github.com/vite-plugin/vite-plugin-dynamic-import/blob/v1.3.0/src/index.ts#L79
+    // https://github.com/vite-plugin/vite-plugin-dynamic-import/blob/v1.3.0/src/index.ts#L133-L135
     if (/node_modules\/(?!\.vite\/)/.test(id)) {
       return true
     }

--- a/README.md
+++ b/README.md
@@ -33,13 +33,27 @@ export default {
 
 cases 👉 [vite-plugin-dynamic-import/test](https://github.com/vite-plugin/vite-plugin-dynamic-import/blob/main/test)
 
+#### node_modules
+
+```js
+dynamicImport({
+  filter(id) {
+    // `node_modules` is exclude by default, so we need to include it explicitly
+    // https://github.com/vite-plugin/vite-plugin-dynamic-import/blob/v1.3.0/src/index.ts#L79
+    if (/node_modules\/(?!\.vite\/)/.test(id)) {
+      return true
+    }
+  }
+})
+```
+
 ## API
 
 dynamicImport([options])
 
 ```ts
 export interface Options {
-  filter?: (id: string) => false | void
+  filter?: (id: string) => boolean | void
   /**
    * ```
    * 1. `true` - Match all possibilities as much as possible, more like `webpack`
@@ -47,9 +61,9 @@ export interface Options {
    * 
    * 2. `false` - It behaves more like `@rollup/plugin-dynamic-import-vars`
    * see https://github.com/rollup/plugins/tree/master/packages/dynamic-import-vars#how-it-works
-   * 
-   * default true
    * ```
+   * 
+   * @defaultValue true
    */
   loose?: boolean
   /**
@@ -58,10 +72,11 @@ export interface Options {
    */
   onFiles?: (files: string[], id: string) => typeof files | void
   /**
-   * It will add `@vite-ignore`  
-   * `import(/*@vite-ignore* / 'import-path')`
+   * Custom importee
+   * 
+   * e.g. - append `\/*@vite-ignore*\/` in front of importee to bypass to Vite
    */
-  viteIgnore?: (rawImportee: string, id: string) => true | void
+  onResolve?: (rawImportee: string, id: string) => typeof rawImportee | void
 }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -33,6 +33,19 @@ export default {
 
 案例 👉 [vite-plugin-dynamic-import/test](https://github.com/vite-plugin/vite-plugin-dynamic-import/blob/main/test)
 
+#### node_modules
+
+```js
+dynamicImport({
+  filter(id) {
+    // 默认会排除 `node_modules`，所以必须显式的包含它
+    // https://github.com/vite-plugin/vite-plugin-dynamic-import/blob/v1.3.0/src/index.ts#L79
+    if (/node_modules\/(?!\.vite\/)/.test(id)) {
+      return true
+    }
+  }
+})
+```
 
 ## API
 
@@ -40,7 +53,7 @@ dynamicImport([options])
 
 ```ts
 export interface Options {
-  filter?: (id: string) => false | void
+  filter?: (id: string) => boolean | void
   /**
    * ```
    * 1. `true` - 尽量匹配所有可能场景, 功能更像 `webpack`
@@ -59,10 +72,11 @@ export interface Options {
    */
   onFiles?: (files: string[], id: string) => typeof files | void
   /**
-   * 将会在 import 中添加 `@vite-ignore`  
-   * `import(/*@vite-ignore* / 'import-path')`
+   * 自定义 importee
+   * 
+   * e.g. - 在 importee 前面插入 `\/*@vite-ignore*\/` 绕过 Vite
    */
-  viteIgnore?: (rawImportee: string, id: string) => true | void
+  onResolve?: (rawImportee: string, id: string) => typeof rawImportee | void
 }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -39,7 +39,7 @@ export default {
 dynamicImport({
   filter(id) {
     // 默认会排除 `node_modules`，所以必须显式的包含它
-    // https://github.com/vite-plugin/vite-plugin-dynamic-import/blob/v1.3.0/src/index.ts#L79
+    // https://github.com/vite-plugin/vite-plugin-dynamic-import/blob/v1.3.0/src/index.ts#L133-L135
     if (/node_modules\/(?!\.vite\/)/.test(id)) {
       return true
     }

--- a/package.json
+++ b/package.json
@@ -2,15 +2,15 @@
   "name": "vite-plugin-dynamic-import",
   "version": "1.3.0",
   "description": "Enhance Vite builtin dynamic import",
-  "type": "module",
-  "main": "index.js",
-  "types": "types",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./index.js",
-      "require": "./index.cjs",
-      "types": "./types/index.d.ts"
-    }
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.js"
+    },
+    "./*": "./*"
   },
   "repository": {
     "type": "git",
@@ -26,6 +26,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "acorn": "^8.8.2",
     "es-module-lexer": "^1.2.1",
     "fast-glob": "^3.2.12"
   },
@@ -45,8 +46,6 @@
     "dynamic"
   ],
   "files": [
-    "types",
-    "index.cjs",
-    "index.js"
+    "dist"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-dynamic-import",
-  "version": "1.2.7",
+  "version": "1.3.0",
   "description": "Enhance Vite builtin dynamic import",
   "type": "module",
   "main": "index.js",
@@ -8,7 +8,8 @@
   "exports": {
     ".": {
       "import": "./index.js",
-      "require": "./index.cjs"
+      "require": "./index.cjs",
+      "types": "./types/index.d.ts"
     }
   },
   "repository": {
@@ -22,9 +23,10 @@
     "build": "vite build",
     "test": "vitest run",
     "types": "tsc",
-    "prepublishOnly": "npm run test && npm run build"
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "es-module-lexer": "^1.2.1",
     "fast-glob": "^3.2.12"
   },
   "devDependencies": {
@@ -32,9 +34,9 @@
     "@types/node": "^18.11.18",
     "node-fetch": "^3.3.0",
     "typescript": "^4.9.4",
-    "vite": "^4.0.4",
-    "vite-plugin-utils": "^0.4.0",
-    "vitest": "^0.27.2"
+    "vite": "^4.3.2",
+    "vite-plugin-utils": "^0.4.2",
+    "vitest": "^0.30.1"
   },
   "keywords": [
     "vite",

--- a/src/dynamic-import-to-glob.ts
+++ b/src/dynamic-import-to-glob.ts
@@ -1,6 +1,4 @@
 import path from 'node:path'
-import type { AcornNode as AcornNode2 } from 'rollup'
-export type AcornNode<T = any> = AcornNode2 & Record<string, T>
 
 const example = 'For example: import(`./foo/${bar}.js`).'
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,15 +59,13 @@ export interface Options {
   onResolve?: (rawImportee: string, id: string) => typeof rawImportee | void
 }
 
-const PLUGIN_NAME = 'vite-plugin-dynamic-import'
-
 export default function dynamicImport(options: Options = {}): Plugin {
   let config: ResolvedConfig
   let resolve: Resolve
   let extensions = DEFAULT_EXTENSIONS
 
   return {
-    name: PLUGIN_NAME,
+    name: 'vite-plugin-dynamic-import',
     configResolved(_config) {
       config = _config
       resolve = new Resolve(_config)

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -147,7 +147,7 @@ export class Resolve {
       ipte = ipte.replace(find, replacement)
     } else {
       // compatible with vite restrictions
-      // https://github.com/vitejs/vite/blob/1e9615d8614458947a81e0d4753fe61f3a277cb3/packages/vite/src/node/plugins/importAnalysis.ts#L672
+      // https://github.com/vitejs/vite/blob/v2.9.15/packages/vite/src/node/plugins/importAnalysis.ts#L714-L717 - 2.x
       const relativePath = relativeify(path.posix.relative(
         // Usually, the `replacement` we use is the directory path
         // So we also use the `path.dirname` path for calculation
@@ -178,8 +178,7 @@ export class Resolve {
       result.importee = importee.slice(1)
       result.importeeRaw = importee
       result.startQuotation = importee.slice(0, 1)
-      // why not `endQuotation` ?
-      // in fact, may be parse `endQuotation` is meaningless
+      // Why not `endQuotation`? May be parse `endQuotation` is meaningless
       // e.g. `import('./foo/' + path)`
     }
     return result

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,1 @@
+type AcornNode<T = any> = import('rollup').AcornNode & Record<string, T>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,8 @@
 import path from 'node:path'
-import type { AcornNode as AcornNode2 } from 'rollup'
 import {
   singlelineCommentsRE,
   multilineCommentsRE,
 } from 'vite-plugin-utils/constant'
-export type AcornNode<T = any> = AcornNode2 & Record<string, T>
 
 // ------------------------------------------------- RegExp
 

--- a/test/fixtures/__snapshots__/main.js
+++ b/test/fixtures/__snapshots__/main.js
@@ -66,7 +66,7 @@
     });
   }
 })();
-// ---- dynamic import runtime functions --S--
+// [vite-plugin-dynamic-import] runtime -S-
 function __variableDynamicImportRuntime0__(path) {
   switch (path) {
     case '@/views/foo':
@@ -198,4 +198,4 @@ function __variableDynamicImportRuntime5__(path) {
     })
   }
 }
-// ---- dynamic import runtime functions --E--
+// [vite-plugin-dynamic-import] runtime -E-

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -26,8 +26,8 @@ beforeAll(async () => {
 describe('vite serve', async () => {
   it('__snapshots__', async () => {
     const mainTs = await (await fetch(`http://localhost:${PORT}/src/main.ts`)).text()
-    const mainJs = fs.readFileSync(path.join(path.join(root, 'dist/main.js')), 'utf8')
-    const mainJsSnap = fs.readFileSync(path.join(path.join(root, '__snapshots__/main.js')), 'utf8')
+    const mainJs = fs.readFileSync(path.join(root, 'dist/main.js'), 'utf8')
+    const mainJsSnap = fs.readFileSync(path.join(root, '__snapshots__/main.js'), 'utf8')
 
     expect(mainTs).string
     expect(mainJs).eq(mainJsSnap)


### PR DESCRIPTION
## [2023-04-28] v1.3.0

**Main changes**

- support Vite's [Pre-Bundling](https://vitejs.dev/guide/dep-pre-bundling.html#dependency-pre-bundling) for [vite-plugin-dynamic-import/issues/48](https://github.com/vite-plugin/vite-plugin-dynamic-import/issues/48)
- use the `es-module-lexer` improve performance
- integrate `vitest` 🌱

**Full commits**

- babb391 docs: v1.3.0
- 0949d3f feat: better build
- c4ef2f6 feat: support Pre-Bundling
- 966eca5 chore: types
- 2d090cb chore: cleanup
- b1a5bab fix: filter `node_modules`, `import.meta`
- e75e3bc log: v1.3.0
- 8972bb4 v1.3.0
- f7a3ab8 doc: v1.3.0
- b34ada6 test: v1.3.0
- 2a4f240 chore: comments
- 17b1eb0 refactor: performance, support node_modules, custom resolve importee
- 8dd5cac feat: integrate vitest 🌱
- 2ea165f chore: cleanup
