### PR TITLE
V1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [2023-06-25] v1.4.1
+
+- e2e4ba6 fix: correct esbuild loader #56, closes [#56](https://github.com/vite-plugin/vite-plugin-dynamic-import/issues/56)
+
 ## [2023-05-14] v1.4.0
 
 - ceb1bba feat: compatible `pnpm`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-dynamic-import",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "Enhance Vite builtin dynamic import",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
 import type { Plugin, ResolvedConfig } from 'vite'
+import type { Loader } from 'esbuild'
 import {
   type ImportSpecifier,
   init as initParseImports,
@@ -106,7 +107,10 @@ export default function dynamicImport(options: Options = {}): Plugin {
             })
 
             if (contents != null) {
-              return { contents }
+              return {
+                contents,
+                loader: id.slice(id.lastIndexOf('.') + 1) as Loader,
+              }
             }
           })
         },


### PR DESCRIPTION
## [2023-06-25] v1.4.1

- e2e4ba6 fix: correct esbuild loader #56, closes [#56](https://github.com/vite-plugin/vite-plugin-dynamic-import/issues/56)