### PR TITLE
refactor: hasDynamicImport comment import issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -163,6 +163,8 @@ async function transformDynamicImport({
   }
 
   if (!imports.length) {
+    // as hasDynamicImports may find import statements within comments, we need to verify results
+    // in the parser. If there are no dynamic imports, we can skip the transform. 
     return null
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,4 @@
 import path from 'node:path'
-import {
-  singlelineCommentsRE,
-  multilineCommentsRE,
-} from 'vite-plugin-utils/constant'
 
 // ------------------------------------------------- RegExp
 
@@ -15,10 +11,14 @@ export const deepImportRE = /^([^@][^/]*)\/|^(@[^/]+\/[^/]+)\//
 
 // ------------------------------------------------- function
 
+/**
+ * @param {string} code - The code to check for dynamic imports.
+ * @returns bool
+ * @description Determines whether a string containing javascript code may contain dynamic imports. It should be noted this is a naive check 
+ * and may produce false positives, especially when import statements may appear in comments or strings. However, removing comments in their
+ * entirety would require parsing the full AST to do so correctly.
+ */
 export function hasDynamicImport(code: string) {
-  code = code
-    .replace(singlelineCommentsRE, '')
-    .replace(multilineCommentsRE, '')
   return dynamicImportRE.test(code)
 }
 

--- a/test/fixtures/__snapshots__/main.ts
+++ b/test/fixtures/__snapshots__/main.ts
@@ -170,6 +170,9 @@ function __variableDynamicImportRuntime4__(path) {
 }
 function __variableDynamicImportRuntime5__(path) {
   switch (path) {
+    case '@/main-with-string-comments':
+    case '@/main-with-string-comments.ts':
+      return import('./main-with-string-comments.ts');
     case '@/views/bar':
     case '@/views/bar.mjs':
       return import('./views/bar.mjs');

--- a/test/fixtures/index.html
+++ b/test/fixtures/index.html
@@ -59,8 +59,13 @@
       <code>import(`@/${id}`)</code>
       <button class="only-alias">views/baz/index.tsx</button>
     </div>
+    <div class="btns-comments-test-alias">
+      <code>import(`@/views/${id}.js`)</code>
+      <button class="comments-test-alias">foo.js</button>
+    </div>
     <hr/>
     <div class="view"></div>
     <script type="module" src="/src/main.ts"></script>
+    <script type="module" src="/src/main-with-string-comments.ts"></script>
   </body>
 </html>

--- a/test/fixtures/src/main-with-string-comments.ts
+++ b/test/fixtures/src/main-with-string-comments.ts
@@ -1,0 +1,21 @@
+(() => {
+  async function setView(id: string) {
+    const url = "http://localhost:3000"; const { msg } = await import(`@/${id}`)
+    document.querySelector('.view')!.innerHTML = msg + url;
+  }
+
+  const views = [
+    {
+      'comments-test-alias': () => setView('foo'),
+    },
+  ]
+
+  for (const view of views) {
+    Object.entries(view).forEach(([className, cb]) => {
+      document.querySelector(`.${className}`)!.addEventListener('click', ev => {
+        (ev.target as HTMLButtonElement).classList.add('active')
+        cb()
+      })
+    })
+  }
+})();

--- a/test/serve.test.ts
+++ b/test/serve.test.ts
@@ -35,7 +35,12 @@ describe('vite serve', async () => {
       const snapFile = fs.readFileSync(path.join(root, file), 'utf8')
 
       expect(response).string
-      expect(distFile).eq(snapFile)
+
+      // Depending on the OS the snap files were generated in, they may have different line endings
+      const distFileWithoutLineEndings = distFile.replace(/\r|\n/g, "");
+      const snapFileWithoutLineEndings = snapFile.replace(/\r|\n/g, "");
+
+      expect(distFileWithoutLineEndings).eq(snapFileWithoutLineEndings)
     }
   })
 })


### PR DESCRIPTION
This PR attempts to resolve the issue described in [issue 74](https://github.com/vite-plugin/vite-plugin-dynamic-import/issues/74). Specifically, this PR removes the regex which remove comments, in favor of simply using the import regex as a quick check, and validating that the code actually has an import statement after parsing the code explicitly. This may come with a small impact to performance, as there are cases where the regex will find an import within a commented block, and parse the code only to find no dynamic import statements, but it ensures the correctness of the program when the regex would otherwise remove valid javascript code, as described in the issue.

Beyond that, this PR also addresses an issue I ran into when trying to run tests, due to what seems to be an OS compatibility issue. By normalizing a few of the paths, I have verified the tests pass on both a colleague's Mac, and my Windows machine.