### PR TITLE
解决当str不为string时, 导致includes方法不存在的问题

### DIFF
--- a/src/dynamic-import-to-glob.ts
+++ b/src/dynamic-import-to-glob.ts
@@ -2,11 +2,15 @@ import path from 'node:path'
 
 const example = 'For example: import(`./foo/${bar}.js`).'
 
-function sanitizeString(str: string) {
-  if (str.includes('*')) {
-    throw new Error('A dynamic import cannot contain * characters.')
+function sanitizeString(str: any) {
+  if(typeof str === "string" ){
+    if (str.includes('*')) {
+      throw new Error('A dynamic import cannot contain * characters.')
+    }
+    return str
+  } else {
+    return "*"
   }
-  return str
 }
 
 function templateLiteralToGlob(node: AcornNode) {


### PR DESCRIPTION
`<li
        v-for="(item, index) of chapterArr"
        :key="index"
        :class="index + 1 === chapterArr.length ? 'total-item' : 'total-item total-mg'"
        :style="`background-image: url(${require(`@/assets/images/home-bg${index+1}.png`)})`"
      ></li>`

${index+1} 两个都会解析AcornNode, 

- index识别为BinaryExpression
- 1识别为Literal

导致sanitizeString方法str非string, 当非string时视为表达式的内容设置为*