### PR TITLE
Fix mappingPath to remove only the extension at the end of the path

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -89,7 +89,7 @@ export function mappingPath(paths: string[], alias?: Record<string, string>) {
       // @/foo
       importee.endsWith(`/index${ext}`) && importee.replace(`/index${ext}`, ''),
       // @/foo/index
-      importee.replace(ext, ''),
+      ext && importee.endsWith(ext) ? importee.slice(0, -ext.length) : importee,
       // @/foo/index.js
       importee,
     ].filter(Boolean) as string[]


### PR DESCRIPTION
Adjust the mappingPath function to ensure it only removes the extension if it is at the end of the path, not the first occurence